### PR TITLE
Fix missing LVGL helper header

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ monitor_speed = 115200
 lib_deps =
     lvgl/lvgl@^8
     lvgl/lv_drivers@^8
+    https://github.com/lvgl/lvgl_esp32_drivers.git
     ; Removed lv_lib_ffmpeg dependency (not available on macOS)
 
 build_flags =


### PR DESCRIPTION
## Summary
- Add `lvgl_esp32_drivers` via direct GitHub URL so `lvgl_helpers.h` is available for ESP32 builds

## Testing
- `platformio run` *(fails: command not found)*
- `pip install platformio` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6892c46a2328832ba67ca4d63bdc50d2