### PR TITLE
Fix lvgl header include path

### DIFF
--- a/include/lvgl/lvgl.h
+++ b/include/lvgl/lvgl.h
@@ -1,0 +1,4 @@
+#ifndef LVGL_INCLUDE_WRAPPER
+#define LVGL_INCLUDE_WRAPPER
+#include <lvgl.h>
+#endif // LVGL_INCLUDE_WRAPPER


### PR DESCRIPTION
## Summary
- add wrapper lvgl header so esp32 drivers can find lvgl.h

## Testing
- `platformio run` *(fails: command not found)*
- `pip install -U platformio` *(fails: Could not find a version that satisfies the requirement platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6892c69b0c04832b982777a574015199