### PR TITLE
Register LVGL display driver to avoid startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pepe-Mood
 
-This project demonstrates a minimal LVGL application on the ESP32-2432S028 board using PlatformIO. It initialises the SD card
-and stubs out playback of an MP4 file stored at `/videos/demo.mp4` on the card.
+This project demonstrates a minimal LVGL application on the ESP32-2432S028 board using PlatformIO. It registers a dummy LVGL display driver so widgets can be created without real hardware rendering, initialises the SD card and stubs out playback of an MP4 file stored at `/videos/pepe-lore.mp4` on the card.
 
 ## Building
 
@@ -18,5 +17,5 @@ and stubs out playback of an MP4 file stored at `/videos/demo.mp4` on the card.
 ## Running
 
 Copy an MP4 file to the `videos` directory on an SD card and insert it into the board. After flashing and resetting, the
-firmware attempts to read and "play" `/videos/demo.mp4`, reporting progress over the serial port. Actual video decoding is
+firmware attempts to read and "play" `/videos/pepe-lore.mp4`, reporting progress over the serial port. Actual video decoding is
 left to a future implementation.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,15 @@
 // simply reads the file; actual video decoding and rendering would need a
 // dedicated library.
 
-static const char *VIDEO_PATH = "/videos/demo.mp4";
+static const char *VIDEO_PATH = "/videos/pepe-lore.mp4";
 static lv_obj_t *status_label;
+
+static void dummy_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p) {
+    lv_disp_flush_ready(disp);
+}
+
+static lv_disp_draw_buf_t draw_buf;
+static lv_color_t buf[240 * 10];
 
 void playVideo(const char *path) {
     File video = SD.open(path);
@@ -39,6 +46,15 @@ void setup() {
     Serial.begin(115200);
     lv_init();
 
+    lv_disp_draw_buf_init(&draw_buf, buf, NULL, LV_HOR_RES_MAX * 10);
+    lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.draw_buf = &draw_buf;
+    disp_drv.flush_cb = dummy_flush;
+    disp_drv.hor_res = 240;
+    disp_drv.ver_res = 320;
+    lv_disp_drv_register(&disp_drv);
+
     status_label = lv_label_create(lv_scr_act());
     lv_obj_center(status_label);
 
@@ -54,5 +70,6 @@ void setup() {
 
 void loop() {
     lv_timer_handler();
+    lv_tick_inc(5);
     delay(5);
 }


### PR DESCRIPTION
## Summary
- add minimal LVGL display driver and tick increment
- document dummy LVGL driver in README
- point demo video path to `/videos/pepe-lore.mp4`

## Testing
- `python3 -m platformio run`


------
https://chatgpt.com/codex/tasks/task_e_6892cbc21b78832b9834dce479168b04