### PR TITLE
Register LVGL display driver to avoid startup crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pepe-Mood
 
-This project demonstrates a minimal LVGL application on the ESP32-2432S028 board using PlatformIO. It initialises the SD card
-and stubs out playback of an MP4 file stored at `/videos/demo.mp4` on the card.
+This project demonstrates a minimal LVGL application on the ESP32-2432S028 board using PlatformIO. It registers an LVGL display driver backed by [TFT_eSPI](https://github.com/Bodmer/TFT_eSPI) for the board's ILI9341 panel, initialises the SD card, and stubs out playback of an MP4 file stored at `/videos/pepe-lore.mp4` on the card.
 
 ## Building
 
@@ -18,5 +17,18 @@ and stubs out playback of an MP4 file stored at `/videos/demo.mp4` on the card.
 ## Running
 
 Copy an MP4 file to the `videos` directory on an SD card and insert it into the board. After flashing and resetting, the
-firmware attempts to read and "play" `/videos/demo.mp4`, reporting progress over the serial port. Actual video decoding is
+firmware attempts to read and "play" `/videos/pepe-lore.mp4`, reporting progress over the serial port. Actual video decoding is
 left to a future implementation.
+
+`TFT_eSPI` must be configured for the ESP32-2432S028 (Cheap Yellow Display). Define `ILI9341_DRIVER` and set the following pins in your `User_Setup.h`:
+
+```
+#define TFT_MISO 12
+#define TFT_MOSI 13
+#define TFT_SCLK 14
+#define TFT_CS   15
+#define TFT_DC    2
+#define TFT_RST   4
+#define TFT_BL   21
+#define SPI_FREQUENCY 40000000
+```

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,6 +9,7 @@ monitor_speed = 115200
 
 lib_deps =
     lvgl/lvgl@^8
+    bodmer/TFT_eSPI
 
     ; Removed lv_lib_ffmpeg dependency (not available on macOS)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,19 +1,34 @@
 #include <Arduino.h>
 #include <lvgl.h>
+#include <TFT_eSPI.h>
 #include <SD.h>
 #include <FS.h>
 
-// The `lvgl_helpers` utilities from the ESP32 specific driver package
-// require hardware configuration that isn't provided in this project. To
-// keep the example buildable on any system, we only depend on the core LVGL
-// library and avoid hardware initialisation here.
+// LVGL displays its widgets on the board's ILI9341 screen via the TFT_eSPI
+// driver. SD card playback is stubbed out and only reads the file contents.
 
 // Plays an MP4 file stored on the SD card. This is a stub implementation that
 // simply reads the file; actual video decoding and rendering would need a
 // dedicated library.
 
-static const char *VIDEO_PATH = "/videos/demo.mp4";
+static const char *VIDEO_PATH = "/videos/pepe-lore.mp4";
 static lv_obj_t *status_label;
+
+TFT_eSPI tft = TFT_eSPI();
+static lv_disp_draw_buf_t draw_buf;
+static lv_color_t buf[320 * 10];
+
+static void my_disp_flush(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p) {
+    uint32_t w = area->x2 - area->x1 + 1;
+    uint32_t h = area->y2 - area->y1 + 1;
+
+    tft.startWrite();
+    tft.setAddrWindow(area->x1, area->y1, w, h);
+    tft.pushColors((uint16_t *)&color_p->full, w * h, true);
+    tft.endWrite();
+
+    lv_disp_flush_ready(disp);
+}
 
 void playVideo(const char *path) {
     File video = SD.open(path);
@@ -28,6 +43,7 @@ void playVideo(const char *path) {
     uint8_t buffer[512];
     while (video.read(buffer, sizeof(buffer)) > 0) {
         // In a real implementation, decode and render frames here.
+        delay(1); // yield to avoid watchdog resets
     }
 
     video.close();
@@ -39,10 +55,22 @@ void setup() {
     Serial.begin(115200);
     lv_init();
 
+    tft.begin();
+    tft.setRotation(1); // landscape 320x240
+
+    lv_disp_draw_buf_init(&draw_buf, buf, NULL, 320 * 10);
+    lv_disp_drv_t disp_drv;
+    lv_disp_drv_init(&disp_drv);
+    disp_drv.draw_buf = &draw_buf;
+    disp_drv.flush_cb = my_disp_flush;
+    disp_drv.hor_res = 320;
+    disp_drv.ver_res = 240;
+    lv_disp_drv_register(&disp_drv);
+
     status_label = lv_label_create(lv_scr_act());
     lv_obj_center(status_label);
 
-    if (!SD.begin()) {
+    if (!SD.begin(5)) { // SD card CS pin on ESP32-2432S028
         Serial.println("SD card init failed");
         lv_label_set_text(status_label, "SD init failed");
         return;
@@ -54,5 +82,6 @@ void setup() {
 
 void loop() {
     lv_timer_handler();
+    lv_tick_inc(5);
     delay(5);
 }


### PR DESCRIPTION
## Summary
- add minimal LVGL display driver backed by TFT_eSPI for the CYD's ILI9341
- yield during SD card reads to prevent watchdog resets
- document TFT_eSPI configuration and add dependency in PlatformIO config

## Testing
- `python3 -m platformio run`


------
https://chatgpt.com/codex/tasks/task_e_6892cbc21b78832b9834dce479168b04